### PR TITLE
.selectMany tests + enumerable support

### DIFF
--- a/src/linq.js
+++ b/src/linq.js
@@ -149,8 +149,8 @@ class Enumerable {
         return new SelectEnumerable(this, fn);
     }
 
-    selectMany(fn = fnSelf) {
-        return new SelectManyEnumerable(this, fn);
+    selectMany(colSelector = fnSelf, resSelector) {
+        return new SelectManyEnumerable(this, colSelector, resSelector);
     }
 
     single(selector = fnTrue) {

--- a/test/select.js
+++ b/test/select.js
@@ -93,4 +93,12 @@ describe('.selectMany', function () {
 
         expect(results.toArray()).to.deep.equal([1,2,3]);
     });
+
+    it('should collapse a simple nested array and transform to new objects', function () {
+        var items = [[1], [2], [3]].asEnumerable();
+
+        var results = items.selectMany(x => x, y => y * 2);
+
+        expect(results.toArray()).to.deep.equal([2,4,6]);
+    });
 });

--- a/test/select.js
+++ b/test/select.js
@@ -101,4 +101,20 @@ describe('.selectMany', function () {
 
         expect(results.toArray()).to.deep.equal([2,4,6]);
     });
+
+    it('should collapse an array containing enumerables', function () {
+        var items = [[1], [2], [3]].asEnumerable();
+
+        var results = items.selectMany(x => x.asEnumerable().select(y => y + 1));
+
+        expect(results.toArray()).to.deep.equal([2,3,4]);
+    });
+
+    it('should collapse an array containing enumerables and transform to new objects', function () {
+        var items = [[1], [2], [3]].asEnumerable();
+
+        var results = items.selectMany(x => x.asEnumerable().select(y => y + 1), z => z * 2);
+
+        expect(results.toArray()).to.deep.equal([4,6,8]);
+    });
 });


### PR DESCRIPTION
the 1st commit here fixes selectMany using a result selector. It wasn't passing the function needed.
the 2nd commit adds some tests for how I think .selectMany should work with enumerables in the collection selector. I fixed it on the previous version, but can't grok how you're doing it now...

specifically, the following works in C#:

```csharp
var arr = new[] { new [] { 1, 2 }, new [] { 3, 4 } };
arr.SelectMany(x => x.Select(y => y + 1)).ToArray();
// -> [2, 3, 4, 5]
```

whereas if I do it currently...
```js
var arr = [[1, 2], [3, 4]].asEnumerable();
arr.selectMany(x => x.asEnumerable.select(y => y + 1)).toArray();
// -> [undefined, undefined]
```